### PR TITLE
Item hover information

### DIFF
--- a/FerngillSimpleEconomy/FerngillSimpleEconomy.cs
+++ b/FerngillSimpleEconomy/FerngillSimpleEconomy.cs
@@ -30,7 +30,7 @@ namespace fse.core
 			_normalDistributionService = new NormalDistributionService();
 			_economyService = new EconomyService(helper, Monitor, _multiplayerService, _fishService, _seedService, _normalDistributionService);
 			_forecastMenuService = new ForecastMenuService(helper, _economyService, Monitor, new DrawTextHelper());
-			_tooltip = new Tooltip(helper, _economyService, _forecastMenuService);
+			_tooltip = new Tooltip(helper, _economyService, _forecastMenuService, Monitor);
 			RegisterPatches(helper);
 			RegisterHandlers(helper);
 			helper.ConsoleCommands.Add("fse_reset", "Fully Resets Ferngill Simple Economy", (_, _) =>

--- a/FerngillSimpleEconomy/FerngillSimpleEconomy.cs
+++ b/FerngillSimpleEconomy/FerngillSimpleEconomy.cs
@@ -3,6 +3,7 @@ using fse.core.helpers;
 using fse.core.models;
 using fse.core.patches;
 using fse.core.services;
+using fse.core.tooltip;
 using HarmonyLib;
 using StardewModdingAPI;
 using StardewValley;
@@ -18,6 +19,7 @@ namespace fse.core
 		private NormalDistributionService _normalDistributionService;
 		private SeedService _seedService;
 		private FishService _fishService;
+		private Tooltip _tooltip;
 
 		public override void Entry(IModHelper helper)
 		{
@@ -28,6 +30,7 @@ namespace fse.core
 			_normalDistributionService = new NormalDistributionService();
 			_economyService = new EconomyService(helper, Monitor, _multiplayerService, _fishService, _seedService, _normalDistributionService);
 			_forecastMenuService = new ForecastMenuService(helper, _economyService, Monitor, new DrawTextHelper());
+			_tooltip = new Tooltip(helper, _economyService, _forecastMenuService);
 			RegisterPatches(helper);
 			RegisterHandlers(helper);
 			helper.ConsoleCommands.Add("fse_reset", "Fully Resets Ferngill Simple Economy", (_, _) =>

--- a/FerngillSimpleEconomy/services/EconomyService.cs
+++ b/FerngillSimpleEconomy/services/EconomyService.cs
@@ -29,6 +29,7 @@ public interface IEconomyService
 	int GetPricePerDay(ItemModel model);
 	ItemModel GetConsolidatedItem(ItemModel original);
 	float GetBreakEvenSupply();
+  ItemModel GetItemModelById(string item);
 }
 
 public class EconomyService(
@@ -446,6 +447,16 @@ public class EconomyService(
 		var baseItem = Economy.GetItem(artisanBase);
 
 		return baseItem ?? baseModel;
+	}
+
+	public ItemModel GetItemModelById(string item)
+	{
+	 ItemModel model = Economy.GetItem(item);
+	 if (model != null)
+	 {
+		return GetConsolidatedItem(model); ;
+	 }
+	 return null;
 	}
 
 	private static int RoundDouble(double d) => (int)Math.Round(d, 0, MidpointRounding.ToEven);

--- a/FerngillSimpleEconomy/services/EconomyService.cs
+++ b/FerngillSimpleEconomy/services/EconomyService.cs
@@ -451,12 +451,17 @@ public class EconomyService(
 
 	public ItemModel GetItemModelById(string item)
 	{
-	 ItemModel model = Economy.GetItem(item);
-	 if (model != null)
+	 Object obj = new Object(item, 1);
+	 if (obj.Category == Object.artisanGoodsCategory)
 	 {
-		return GetConsolidatedItem(model); ;
+		obj = GetArtisanBase(obj);
 	 }
-	 return null;
+	 ItemModel model = Economy.GetItem(obj);
+	 if (model == null)
+	 {
+		return null;
+	 }
+	 return GetConsolidatedItem(model);
 	}
 
 	private static int RoundDouble(double d) => (int)Math.Round(d, 0, MidpointRounding.ToEven);

--- a/FerngillSimpleEconomy/tooltip/Readme.md
+++ b/FerngillSimpleEconomy/tooltip/Readme.md
@@ -1,0 +1,4 @@
+Many of the concepts in the tooltip section were modified or copied from other mods
+
+* tooltip drawing
+	logic [https://github.com/musbah/StardewValleyMods/blob/master/BundleTooltips/ModEntry.cs](https://github.com/musbah/StardewValleyMods/blob/master/BundleTooltips/ModEntry.cs)

--- a/FerngillSimpleEconomy/tooltip/Tooltip.cs
+++ b/FerngillSimpleEconomy/tooltip/Tooltip.cs
@@ -1,0 +1,152 @@
+﻿using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+using Microsoft.Xna.Framework.Input;
+using StardewModdingAPI.Events;
+using StardewModdingAPI;
+using StardewValley.Menus;
+using StardewValley;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using fse.core.menu;
+using fse.core.models;
+using fse.core.services;
+using fse.core.patches;
+using HarmonyLib;
+using static System.Net.Mime.MediaTypeNames;
+
+namespace fse.core.tooltip
+{
+ internal class Tooltip
+ {
+	private static IModHelper _helper;
+	private static AbstractForecastMenu _forecastMenu;
+	private static IEconomyService _econService;
+	private static IForecastMenuService _forecastMenuService;
+	private Item toolbarItem;
+	private bool isUiInfoSuiteLoaded;
+
+	//Constructor
+	public Tooltip(IModHelper helper, IEconomyService econService, IForecastMenuService forecastMenuService)
+	{
+	 _helper = helper;
+	 _econService = econService;
+	 _forecastMenuService = forecastMenuService;
+
+	 _forecastMenu = _forecastMenuService.CreateMenu();
+
+	 isUiInfoSuiteLoaded = _helper.ModRegistry.IsLoaded("Annosz.UiInfoSuite2"); 
+
+	 _helper.Events.Display.RenderingHud += PreRenderHud;
+	 _helper.Events.Display.RenderedHud += PostRenderHud;
+	 _helper.Events.Display.RenderedActiveMenu += PostRenderGui;
+	}
+
+	//Get hovered toolbar item
+	public void PreRenderHud(object sender, RenderingHudEventArgs e)
+	{
+	 toolbarItem = null;
+	 foreach (IClickableMenu menu in Game1.onScreenMenus)
+	 {
+		if (menu is Toolbar toolbar)
+		{
+		 toolbarItem = _helper.Reflection.GetField<Item>(menu, "hoverItem").GetValue();
+		 return;
+		}
+	 }
+	}
+
+	//Render for toolbar item
+	public void PostRenderHud(object sender, RenderedHudEventArgs e)
+	{
+	 if (Game1.activeClickableMenu == null && toolbarItem != null)
+	 {
+		PopulateHoverTextBoxAndDraw(toolbarItem, true);
+		toolbarItem = null;
+	 }
+	}
+
+	//Render for menu item
+	public void PostRenderGui(object sender, RenderedActiveMenuEventArgs e)
+	{
+	 if (Game1.activeClickableMenu != null)
+	 {
+		Item item = this.GetHoveredItemFromMenu(Game1.activeClickableMenu);
+		if (item != null)
+		 PopulateHoverTextBoxAndDraw(item, false);
+	 }
+	}
+
+	//Get hovered menu item
+	private Item GetHoveredItemFromMenu(IClickableMenu menu)
+	{
+	 // game menu
+	 if (menu is GameMenu gameMenu)
+	 {
+		IClickableMenu page = _helper.Reflection.GetField<List<IClickableMenu>>(gameMenu, "pages").GetValue()[gameMenu.currentTab];
+		if (page is InventoryPage)
+		 return _helper.Reflection.GetField<Item>(page, "hoveredItem").GetValue();
+	 }
+	 // from inventory UI (so things like shops and so on)
+	 else if (menu is MenuWithInventory inventoryMenu)
+	 {
+		return inventoryMenu.hoveredItem;
+	 }
+
+	 return null;
+	}
+
+	//Populate and draw
+	private void PopulateHoverTextBoxAndDraw(Item item, bool fromToolbar)
+	{
+	 String itemid = item.ItemId;
+	 String itemname = item.DisplayName;
+
+	 ItemModel model = _econService.GetItemModelById(itemid);
+	 if (model != null)
+	 {
+		Seasons allSeasons = Seasons.Spring | Seasons.Summer | Seasons.Fall | Seasons.Winter;
+		if (_econService.ItemValidForSeason(model, allSeasons))
+		{
+		 this.DrawHoverTextBox(Game1.smallFont, fromToolbar, model);
+		}
+	 }
+
+	}
+
+	//Draw
+	private void DrawHoverTextBox(SpriteFont font, bool fromToolbar, ItemModel model)
+	{
+	 int width = 240;
+	 int height = 110;
+
+	 //int x = (int)(Mouse.GetState().X - width / Game1.options.zoomLevel) - Game1.tileSize / 2;
+	 //int y = (int)(Mouse.GetState().Y / Game1.options.zoomLevel) + Game1.tileSize / 2;
+	 int x = (int)(Mouse.GetState().X / Game1.options.uiScale) - Game1.tileSize / 2 - width;
+	 int y = (int)(Mouse.GetState().Y / Game1.options.uiScale) + Game1.tileSize / 3;
+
+	 //So that the tooltips don't overlap
+	 if ((isUiInfoSuiteLoaded))
+	 {
+		x -= 140;
+	 }
+
+	 if (x < 0)
+	 {
+		x = 0;
+	 }
+
+	 if (y + height > Game1.graphics.GraphicsDevice.Viewport.Height)
+	 {
+		y = Game1.graphics.GraphicsDevice.Viewport.Height - height;
+	 }
+
+	 IClickableMenu.drawTextureBox(Game1.spriteBatch, Game1.menuTexture, new Rectangle(0, 256, 60, 60), x, y, width+20, height, Color.White);
+	 _forecastMenu.DrawSupplyBar(Game1.spriteBatch, x+15, y+20, x+width, (Game1.tileSize / 2), model);
+
+
+	}
+ }
+}


### PR DESCRIPTION
Shows supply bar for item on hover.
Quick & dirty, not fully tested

Moves tooltip left if UiInfoSuite2 is installed so tooltips don't overlap.

Tooltip code largely copied from https://github.com/musbah/StardewValleyMods/tree/master