### PR TITLE
Console command  - Reset daily supply

### DIFF
--- a/FerngillSimpleEconomy/FerngillSimpleEconomy.cs
+++ b/FerngillSimpleEconomy/FerngillSimpleEconomy.cs
@@ -40,6 +40,16 @@ public class FerngillSimpleEconomy : Mod
 			economyService.Reset();
 			economyService.AdvanceOneDay();
 		});
+		helper.ConsoleCommands.Add("fse_reset_daily", "Resets Daily Supply Change of Ferngill Simple Economy", (_, _) =>
+		{
+		 if (!Game1.player.IsMainPlayer)
+		 {
+			return;
+		 }
+
+		 economyService.ResetDaily();
+		 economyService.AdvanceOneDay();
+		});
 	}
 
 	private void RegisterPatches

--- a/FerngillSimpleEconomy/services/EconomyService.cs
+++ b/FerngillSimpleEconomy/services/EconomyService.cs
@@ -19,6 +19,7 @@ public interface IEconomyService
 	void SetupForNewSeason();
 	void SetupForNewYear();
 	void Reset();
+	void ResetDaily();
 	void AdvanceOneDay();
 	Dictionary<int, string> GetCategories();
 	ItemModel[] GetItemsForCategory(int category);
@@ -186,6 +187,15 @@ public class EconomyService(
 		QueueSave();
 	}
 
+	public void ResetDaily()
+	{
+	 if (IsClient)
+	 {
+		return;
+	 }
+	 RandomizeEconomy(Economy, false, true, SeasonHelper.GetCurrentSeason());
+	 QueueSave();
+	}
 
 	private void RandomizeEconomy(EconomyModel model, bool updateSupply, bool updateDelta, Seasons season)
 	{


### PR DESCRIPTION
This adds a console command to reset the daily supply, the one that normally only happens at the end of a season. 

I personally use it weekly to add a bit more risk management to the game. Also eases the problem that at the end of the year supply tends to be super low or super high. 

